### PR TITLE
Add support for `soft_fail` attribute

### DIFF
--- a/src/bkyml/skeleton.py
+++ b/src/bkyml/skeleton.py
@@ -507,6 +507,12 @@ class Command:
             metavar="BOOL_OR_STRING"
         )
         parser.add_argument(
+            '--soft-fail',
+            help="Allow specified non-zero exit statuses not to fail the build.",
+            type=int_or_star,
+            metavar='INT_OR_STAR'
+        )
+        parser.add_argument(
             '--retry',
             help="The conditions for retrying this step.",
             choices=['automatic', 'manual']
@@ -664,6 +670,13 @@ class Command:
         if ns_hasattr(namespace, 'skip') \
            and (namespace.skip is True or isinstance(namespace.skip, str)):
             step['skip'] = namespace.skip
+
+        # soft_fail
+        if ns_hasattr(namespace, 'soft_fail'):
+            if namespace.soft_fail == '*':
+                step['soft_fail'] = True
+            else:
+                step['soft_fail'] = { 'exit_status': namespace.soft_fail }
 
         # retry
         if ns_hasattr(namespace, 'retry'):

--- a/tests/snapshots/snap_test_skeleton.py
+++ b/tests/snapshots/snap_test_skeleton.py
@@ -36,7 +36,7 @@ snapshots['test_help 4'] = '''usage:  command [-h] --command COMMAND [COMMAND ..
                 [--parallelism POSITIVE_NUMBER] [--concurrency POSITIVE_INT]
                 [--concurrency-group GROUP_NAME]
                 [--timeout-in-minutes TIMEOUT] [--skip BOOL_OR_STRING]
-                [--retry {automatic,manual}]
+                [--soft-fail INT_OR_STAR] [--retry {automatic,manual}]
                 [--retry-automatic-exit-status INT_OR_STAR]
                 [--retry-automatic-limit POSITIVE_INT]
                 [--retry-automatic-tuple INT_OR_STAR POSITIVE_INT]
@@ -78,6 +78,9 @@ optional arguments:
                         build will fail.
   --skip BOOL_OR_STRING
                         Whether to skip this step or not.
+  --soft-fail INT_OR_STAR
+                        Allow specified non-zero exit statuses not to fail the
+                        build.
   --retry {automatic,manual}
                         The conditions for retrying this step.
   --retry-automatic-exit-status INT_OR_STAR
@@ -268,6 +271,15 @@ snapshots['test_skip_bool_false 1'] = '''  - command: cmd
 
 snapshots['test_skip_string 1'] = '''  - command: cmd
     skip: Some reason
+'''
+
+snapshots['test_soft_fail 1'] = '''  - command: cmd
+    soft_fail: true
+'''
+
+snapshots['test_soft_fail_1 1'] = '''  - command: cmd
+    soft_fail:
+      exit_status: 1
 '''
 
 snapshots['test_env_all 1'] = '''env:

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -342,6 +342,14 @@ def describe_bkyaml():
             args.skip = 'Some reason'
             generic_command_call(args, snapshot)
 
+        def test_soft_fail(args, snapshot):
+            args.soft_fail = '*'
+            generic_command_call(args, snapshot)
+
+        def test_soft_fail_1(args, snapshot):
+            args.soft_fail = 1
+            generic_command_call(args, snapshot)
+
         def describe_retry():
             def test_retry_unknown(args, snapshot):
                 args.retry = 'unknown'


### PR DESCRIPTION
 Buildkite now has a [`soft_fail`](https://buildkite.com/docs/pipelines/command-step#soft-fail-attributes) attribute. This PR adds support for it. 

Lifted with slight changes from https://github.com/henrypoon/bkyml/commit/4ebbcec10bb679bcd1a8055903a21c6773ee120d